### PR TITLE
change conditional back to explicit if/else

### DIFF
--- a/requires_conditional/conanfile.py
+++ b/requires_conditional/conanfile.py
@@ -15,7 +15,10 @@ class HelloConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["WITH_ZIP"] = bool(self.options.zip)
+        if self.options.zip:
+            cmake.definitions["WITH_ZIP"] = "1"
+        else:
+            cmake.definitions["WITH_ZIP"] = "0"
         cmake.configure(source_folder="src")
         cmake.build()
 


### PR DESCRIPTION
doing this because in the training we say: "if you're new to python, you can refer to the build() method as an example of how to write a conditional.