### PR TITLE
Add hardcoded nameserver

### DIFF
--- a/docker_environment/Dockerfile
+++ b/docker_environment/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update \
        less \
        g++-arm-linux-gnueabihf \
        cmake
-
+RUN echo -e "nameserver 8.8.8.8" > /etc/resolv.conf
 USER conan
 
 RUN git clone https://github.com/conan-io/training


### PR DESCRIPTION
Adding hardcoded Google Public DNS IP addresses (IPv4) to /etc/resolv.conf
This avoids having the default value of the localhost IP 127.0.X.X in case docker is running on a virtual machine.
Fixes #35