### PR TITLE
change artifactory server name to workaround bug in base URL field validation

### DIFF
--- a/docker_environment/artifactory-training/scripts/set-internal-hostname.sh
+++ b/docker_environment/artifactory-training/scripts/set-internal-hostname.sh
@@ -7,4 +7,8 @@ curl -m 5 -f -X PATCH \
 http://localhost:8082/artifactory/api/system/configuration \
 -d '
 urlBase: http://jfrog-artifactory-training:8082
+localRepositories: #Local repositories configuration
+     conan-tmp: #The local repository name
+          type: conan #The package type
 '
+# we also create a repository here to bypass the first-run wizard

--- a/docker_environment/artifactory-training/scripts/set-internal-hostname.sh
+++ b/docker_environment/artifactory-training/scripts/set-internal-hostname.sh
@@ -6,5 +6,5 @@ curl -m 5 -f -X PATCH \
 -H 'Content-Type: application/yaml' \
 http://localhost:8082/artifactory/api/system/configuration \
 -d '
-urlBase: http://artifactory-training:8082
+urlBase: http://jfrog-artifactory-training:8082
 '

--- a/docker_environment/docker-compose.yml
+++ b/docker_environment/docker-compose.yml
@@ -10,8 +10,8 @@ services:
             - conan-training
         command: tail -f /dev/null
 
-    artifactory-training:
-        container_name: artifactory-training
+    jfrog-artifactory-training:
+        container_name: jfrog-artifactory-training
         build:
             dockerfile: Dockerfile
             context: ./artifactory-training


### PR DESCRIPTION
To fix https://github.com/conan-io/training/issues/40

Long story short, there seems to be a bug (pending artifactory dev team confirmation).  If use the Artifactory REST API to set the `baseUrl` field to contain the string `/artifactory` anywhere in the URL, we can reproduce the error reported:

>artifactory-training    | 2020-10-12T06:34:01.261Z [jfrt ] [ERROR] [b41cf493e3dd3f2f] [ctoryContextConfigListener:116] [art-init            ] - Application could not be initialized: Found active HA servers in DB, Community Edition for C/C++ is not supported in by active HA environment. Shutting down Artifactory.

The error message seems to be erroneous and misleading. 

When pasting the URL `http://artifactory-training:8082` into the first-run wizard as the "baseURL" field, it was disallowed with the message:
> please remove `/artifactory` from the URL

It took a LONG TIME to find this because the error message doesn't appear when setting the value in the normal "General Settings" screen, nor when setting the value via the Artifactory REST API. It seems that only the first run wizard has the validation logic. It ONLY appears when setting the value via the first-run wizard. 

Initially, I assumed it was a just an ill-conceived form validation for that one page. After trial and error, it seems that setting the baseURL value to a string which contains `/artifactory` anywhere causes the "Found active HA servers" error which was reported. By simply adding `jfrog-` in front of the word artifactory, I am no longer able to reproduce the error.  It seems possible/likely that this specific error only appears for the Artifactory CE edition because it has text specific to that. It's possible that this string is disallowed across all versions, and in other non-free versions, the error message produced is accurate and relevant. 

In any case, will request the original reporter to test this solution.


![image](https://user-images.githubusercontent.com/8557737/95945668-fe81e000-0db8-11eb-8b92-b12878251ffd.png)
