### PR TITLE
remove windows eol on sh scripts

### DIFF
--- a/docker_environment/artifactory-training/Dockerfile
+++ b/docker_environment/artifactory-training/Dockerfile
@@ -4,7 +4,11 @@ COPY scripts/* /scripts/
 
 USER root
 
+#Set executable permission
 RUN chmod +x /scripts/*
+
+#Remove windows EOL character
+RUN sed -i "s/\r//g" /scripts/*
 
 RUN chown -hR artifactory:artifactory /scripts
 


### PR DESCRIPTION
fixes https://github.com/conan-io/training/issues/50

the default configuration for git-for-windows contains an item called `autocrlf` which converts all unix line endings to windows ones in the working directory.  rather than suggesting that users disable this setting, we simply force replace windows line endings with unix ones before running the scripts. 