### PR TITLE
Fix docker-compose connection to artifactory port

### DIFF
--- a/docker_environment/docker-compose.yml
+++ b/docker_environment/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         networks:
             - conan-training
         ports:
-            - "8082:8082"
+            - "8082:8081"
         restart: always
 
 networks:


### PR DESCRIPTION
In the docker-compose file, the Artifactory container exposes port 8081 to the network, but it forwards port 8082 to the host. Forwarding the container port 8081 to the hosts 8081 allowed me to see the Artifactory UI.

In this screenshot the training containers can be seen in the current configuration.
![image](https://user-images.githubusercontent.com/22322118/109761027-0cad8d00-7bf0-11eb-9e24-5de82f1a94b2.png)